### PR TITLE
removed unused import / variable warnings

### DIFF
--- a/src/main/java/frc/lib/drivers/TalonFXFactory.java
+++ b/src/main/java/frc/lib/drivers/TalonFXFactory.java
@@ -17,7 +17,7 @@ import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
-import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod;
+import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod; // FIXME this is deprecated
 import com.ctre.phoenix.sensors.SensorInitializationStrategy;
 
 import frc.robot.Constants;

--- a/src/main/java/frc/lib/drivers/TalonFXUtil.java
+++ b/src/main/java/frc/lib/drivers/TalonFXUtil.java
@@ -14,7 +14,6 @@ import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 
 import frc.lib.util.TelemetryUtil;
 import frc.lib.util.TelemetryUtil.PrintStyle;
-import frc.robot.Constants;
 
 /**
  * Add your docs here.

--- a/src/main/java/frc/lib/drivers/TalonSRXFactory.java
+++ b/src/main/java/frc/lib/drivers/TalonSRXFactory.java
@@ -14,7 +14,7 @@ import com.ctre.phoenix.motorcontrol.LimitSwitchNormal;
 import com.ctre.phoenix.motorcontrol.LimitSwitchSource;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
-import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod;
+import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod; // FIXME this is deprecated
 
 import frc.robot.Constants;
 

--- a/src/main/java/frc/lib/util/Controller.java
+++ b/src/main/java/frc/lib/util/Controller.java
@@ -2,17 +2,10 @@ package frc.lib.util;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.button.Button;
-import edu.wpi.first.wpilibj2.command.button.POVButton;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public class Controller {
     private XboxController xbox;
-    private static final byte DPAD_U_PORT = -1;
-    private static final byte DPAD_D_PORT = -3;
-    private static final byte DPAD_L_PORT = -4;
-    private static final byte DPAD_R_PORT = -2;
     private Button a, b, x, y, rb, lb, lstick, rstick, back, start;
-    private POVButton up, down, left, right;
     public Controller(XboxController xbox){
         this.xbox = xbox;
         a = new Button(xbox::getAButton);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,10 +8,7 @@ import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.commands.DiagnosticTestCommand;
-import frc.robot.commands.CAS.RobotOff;
 import frc.robot.factories.AutonomousCommandFactory;
-import frc.robot.subsystems.*;
 
 /**
  * The VM is configured to automatically run this class, and to call the

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,44 +4,21 @@
 package frc.robot;
 
 import frc.lib.util.Controller;
-import frc.lib.util.DeviceFinder;
-import frc.robot.commands.*;
 import frc.robot.commands.CAS.AimShoot;
 import frc.robot.commands.CAS.EjectBall;
 import frc.robot.commands.CAS.RobotIdle;
 import frc.robot.commands.CAS.RobotOff;
 import frc.robot.commands.SetSubsystemCommand.*;
-import frc.robot.factories.AutonomousCommandFactory;
 import frc.robot.subsystems.ClimbSubsystem;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IndexerSubsystem;
-import frc.robot.subsystems.LimelightSubsystem;
 import frc.robot.subsystems.PivotSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 import static frc.robot.Constants.*;
-
-import java.util.function.BooleanSupplier;
-
-import com.ctre.phoenix.motorcontrol.ControlMode;
-
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.PowerDistribution;
-import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import edu.wpi.first.wpilibj.shuffleboard.EventImportance;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * This class is where the bulk of the robot should be declared. Since
@@ -56,11 +33,7 @@ public class RobotContainer {
 
   // The robot's subsystems and commands are defined here...
   private DrivetrainSubsystem m_drivetrainSubsystem;
-  private LimelightSubsystem m_limelight;
-  private IndexerSubsystem m_indexerSubsystem;
   private ShooterSubsystem m_shooterSubsystem;
-  private ClimbSubsystem m_climbSubsystem;
-  private PivotSubsystem m_pivotSubsystem;
   
   /*private static PowerDistribution powerModule = new PowerDistribution(1, ModuleType.kRev);
 
@@ -71,12 +44,8 @@ public class RobotContainer {
    * The container for the robot. Contains subsystems, OI devices, and commands.
    */
   public RobotContainer() {
-    m_drivetrainSubsystem = DrivetrainSubsystem.getInstance();
-    m_limelight = LimelightSubsystem.getInstance();
-    m_indexerSubsystem = IndexerSubsystem.getInstance();
-    m_shooterSubsystem = ShooterSubsystem.getInstance();
-    m_climbSubsystem = ClimbSubsystem.getInstance();
-    m_pivotSubsystem = PivotSubsystem.getInstance();
+    this.m_drivetrainSubsystem = DrivetrainSubsystem.getInstance();
+    this.m_shooterSubsystem = ShooterSubsystem.getInstance();
 
     // Set the scheduler to log Shuffleboard events for command initialize,
     // interrupt, finish
@@ -104,14 +73,6 @@ public class RobotContainer {
     SmartDashboard.putBoolean("Limelight Connected?", LimelightSubsystem.getInstance().isConnected());
     SmartDashboard.putBoolean("Can Bus Connected?", isCanConnected());
     SmartDashboard.putBoolean("Battery Charged?", isBatteryCharged());*/
-  }
-
-  private static boolean isBatteryCharged(){
-    return RobotController.getBatteryVoltage() >= Constants.kMinimumBatteryVoltage;
-  }
-
-  private static boolean isCanConnected(){
-    return DeviceFinder.Find().size() == Constants.kCanDeviceCount;
   }
   // configures button bindings to controller
   private void configureButtonBindings() {

--- a/src/main/java/frc/robot/commands/CAS/AimShoot.java
+++ b/src/main/java/frc/robot/commands/CAS/AimShoot.java
@@ -1,27 +1,14 @@
 package frc.robot.commands.CAS;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.ProfiledPIDController;
-import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.ProfiledPIDCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import frc.lib.util.Controller;
 import frc.robot.Constants;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.commands.TeleopDriveCommand;
-import frc.robot.commands.SetSubsystemCommand.SetIndexerCommand;
-import frc.robot.commands.SetSubsystemCommand.SetIntakeCommand;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IndexerSubsystem;
-import frc.robot.subsystems.LimelightSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 
 public class AimShoot extends TeleopDriveCommand{ //REPLACABLE BY AIM SEQUENCE

--- a/src/main/java/frc/robot/commands/CAS/EjectBall.java
+++ b/src/main/java/frc/robot/commands/CAS/EjectBall.java
@@ -1,33 +1,12 @@
 package frc.robot.commands.CAS;
 
-import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.ProfiledPIDController;
-import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.ProfiledPIDCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import frc.lib.util.Controller;
 import frc.robot.Constants;
-import frc.robot.RobotContainer;
-import frc.robot.Constants.DriveConstants;
-import frc.robot.commands.TeleopDriveCommand;
-import frc.robot.commands.SetSubsystemCommand.SetIndexerCommand;
-import frc.robot.commands.SetSubsystemCommand.SetIntakeCommand;
-import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IndexerSubsystem;
-import frc.robot.subsystems.LimelightSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 
 public class EjectBall extends CommandBase{ //REPLACABLE BY AIM SEQUENCE
-    private PIDController m_thetaController;
-    private Translation2d m_targetPosition = Constants.targetHudPosition;
     private final ShooterSubsystem m_shooter;
     private final IndexerSubsystem m_indexer;
 

--- a/src/main/java/frc/robot/commands/CAS/RobotIdle.java
+++ b/src/main/java/frc/robot/commands/CAS/RobotIdle.java
@@ -1,11 +1,7 @@
 package frc.robot.commands.CAS;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import static frc.robot.Constants.*;
-import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IndexerSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 

--- a/src/main/java/frc/robot/commands/CAS/RobotOff.java
+++ b/src/main/java/frc/robot/commands/CAS/RobotOff.java
@@ -1,11 +1,6 @@
 package frc.robot.commands.CAS;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
-import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IndexerSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 

--- a/src/main/java/frc/robot/commands/DiagnosticTestCommand.java
+++ b/src/main/java/frc/robot/commands/DiagnosticTestCommand.java
@@ -1,10 +1,7 @@
 package frc.robot.commands;
 
-import javax.lang.model.element.ModuleElement;
 
-import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.factories.AutonomousCommandFactory;
 import frc.robot.subsystems.DrivetrainSubsystem;
@@ -17,18 +14,12 @@ public class DiagnosticTestCommand extends CommandBase{
     private ShooterSubsystem m_shooterSubsystem;
     //private static PowerDistribution m_pd = new PowerDistribution(1, PowerDistribution.ModuleType.kRev);
 
-    private final double expectedPeakDriveVelocity = 0;
-    private final double expectedPeakIndexerVelocity = 0;
-    private final double expectedPeakIntakeVelocity = 0;
-    private final double expectedPeakShooterVelocity = 0;
-
     private double actualPeakDriveVelocity = 0;
     private double actualPeakIndexerVelocity = 0;
     private double actualPeakIntakeVelocity = 0;
     private double actualPeakShooterVelocity = 0;
 
     private final Timer m_timer = new Timer();
-    private final double testingTime = 3;
 
     public DiagnosticTestCommand(){
         m_drivetrainSubsystem = DrivetrainSubsystem.getInstance();

--- a/src/main/java/frc/robot/commands/SetSubsystemCommand/SetIntakeIndexerCommand.java
+++ b/src/main/java/frc/robot/commands/SetSubsystemCommand/SetIntakeIndexerCommand.java
@@ -1,6 +1,5 @@
 package frc.robot.commands.SetSubsystemCommand;
 
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.IndexerSubsystem;
 

--- a/src/main/java/frc/robot/commands/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/commands/TeleopDriveCommand.java
@@ -1,10 +1,8 @@
 package frc.robot.commands;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.lib.util.Controller;

--- a/src/main/java/frc/robot/commands/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/commands/TeleopDriveCommand.java
@@ -39,16 +39,17 @@ public class TeleopDriveCommand extends CommandBase {
         // get joystick input for drive
         var xSpeed = -modifyAxis(m_controller.getLeftY()) * DriveConstants.kMaxSpeedMetersPerSecond;
         var ySpeed = -modifyAxis(m_controller.getLeftX()) * DriveConstants.kMaxSpeedMetersPerSecond;
-        // var rot = -modifyAxis(m_controller.getRightX()*0.7) * DriveConstants.kMaxAngularSpeedRadiansPerSecond;
+        // regular turning
+        var rot = -modifyAxis(m_controller.getRightX()*0.7) * DriveConstants.kMaxAngularSpeedRadiansPerSecond;
 
         // field-oriented turning test
-        var turnAngleX = m_controller.getRightX();
-        var turnAngleY = m_controller.getRightY();
-        double currentRotation = m_drivetrainSubsystem.getGyroscopeRotation().getRadians();
-        double targetAngle = calculateTurnAngle(-turnAngleY, -turnAngleX, currentRotation);
-        double rot = m_thetaController.calculate(currentRotation,targetAngle);
+        // var turnAngleX = m_controller.getRightX();
+        // var turnAngleY = m_controller.getRightY();
+        // double currentRotation = m_drivetrainSubsystem.getGyroscopeRotation().getRadians();
+        // double targetAngle = calculateTurnAngle(-turnAngleY, -turnAngleX, currentRotation);
+        // double rot = m_thetaController.calculate(currentRotation,targetAngle);
         // variable turn speed control
-        rot *= Math.hypot(turnAngleX, turnAngleY);
+        // rot *= Math.hypot(turnAngleX, turnAngleY);
 
 
         SmartDashboard.putNumber("xSpeed", xSpeed);
@@ -61,19 +62,6 @@ public class TeleopDriveCommand extends CommandBase {
             rotFilter.calculate(rot), m_drivetrainSubsystem.getGyroscopeRotation()));
         /*m_drivetrainSubsystem.drive(new ChassisSpeeds(driveXFilter.calculate(xSpeed), driveYFilter.calculate(ySpeed), 
         rotFilter.calculate(rot)));*/
-    }
-
-    private static double calculateTurnAngle(double xValue, double yValue, double currentRotation) {
-        if(modifyAxis(xValue) == 0 && modifyAxis(yValue) == 0) {
-            return currentRotation;
-        } else {
-            double calculatedAngle = Math.atan2(yValue, xValue);
-            if(Math.abs(calculatedAngle-currentRotation) < Math.toRadians(6)) {
-                return currentRotation;
-            } else {
-                return calculatedAngle;
-            }
-        }
     } 
 
     public static double applyDeadband(double value, double deadband) {

--- a/src/main/java/frc/robot/factories/AutonomousCommandFactory.java
+++ b/src/main/java/frc/robot/factories/AutonomousCommandFactory.java
@@ -1,15 +1,11 @@
 package frc.robot.factories;
 import edu.wpi.first.math.geometry.*;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.commands.*;
-import frc.robot.commands.CAS.AimShoot;
 import frc.robot.commands.CAS.RobotOff;
 import frc.robot.commands.SetSubsystemCommand.*;
 import frc.robot.subsystems.DrivetrainSubsystem;

--- a/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
@@ -1,14 +1,11 @@
 package frc.robot.subsystems;
 
-import java.io.ObjectInputFilter.Status;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrame;
-import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
-import edu.wpi.first.wpilibj.motorcontrol.Talon;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.drivers.LazyTalonFX;
@@ -16,8 +13,6 @@ import frc.lib.drivers.LazyTalonSRX;
 import frc.lib.drivers.TalonFXFactory;
 import frc.lib.drivers.TalonSRXFactory;
 import frc.robot.Constants;
-import frc.robot.Robot;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.Ports;
 
 public class ClimbSubsystem extends SubsystemBase {

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -12,18 +12,11 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.SPI;
-import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
-import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.RobotContainer;
 import frc.robot.commands.TeleopDriveCommand;
 
 import static frc.robot.Constants.DriveConstants;

--- a/src/main/java/frc/robot/subsystems/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IndexerSubsystem.java
@@ -1,6 +1,5 @@
 package frc.robot.subsystems;
 
-import java.time.Period;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
@@ -14,9 +13,7 @@ import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.lib.drivers.LazyTalonFX;
 import frc.lib.drivers.TalonFXFactory;
 import frc.robot.Constants;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.Ports;
-import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 

--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.networktables.*;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -9,7 +8,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class LimelightSubsystem extends SubsystemBase {
     private static LimelightSubsystem instance = null;
     private NetworkTable nt;
-    private boolean driverMode = false;
 
     public static LimelightSubsystem getInstance(){
         if(instance == null){

--- a/src/main/java/frc/robot/subsystems/PivotSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PivotSubsystem.java
@@ -15,8 +15,6 @@ import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrame;
 
 import frc.robot.Constants;
-import frc.robot.Robot;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.Ports;
 
 public class PivotSubsystem extends SubsystemBase {

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -13,8 +13,6 @@ import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrame;
 
 import frc.robot.Constants;
-import frc.robot.Robot;
-import frc.robot.RobotContainer;
 import frc.robot.Constants.Ports;
 
 public class ShooterSubsystem extends SubsystemBase {


### PR DESCRIPTION
90% of the warnings were from unused variables and unused imports, there were over 100. It did not take that long to remove them.

This may or may not have broken the bot or some of the code idk, I didn't test it lmao

**the other warnings were from deprecated methods or imports.** I don't know WPILib well enough to be able to replace it with a non-deprecated version so I just added a `FIXME`

kinda just realized I may or may not have changed some stuff inside the `lib` directory, but since these were still warning removal and / or comment additions for deprecated libraries I think it should be fine.